### PR TITLE
Fix usage of dangling pointer

### DIFF
--- a/objc/EmiSockDelegate.h
+++ b/objc/EmiSockDelegate.h
@@ -58,8 +58,8 @@ public:
     void connectionGotMessage(EC *conn,
                               EmiUdpSocket<EmiBinding> *socket,
                               EmiTimeInterval now,
-                              const sockaddr_storage& inboundAddress,
-                              const sockaddr_storage& remoteAddress,
+                              sockaddr_storage inboundAddress,
+                              sockaddr_storage remoteAddress,
                               NSData *data,
                               size_t offset,
                               size_t len);

--- a/objc/EmiSockDelegate.mm
+++ b/objc/EmiSockDelegate.mm
@@ -106,8 +106,8 @@ void EmiSockDelegate::connectionOpened(ConnectionOpenedCallbackCookie& cookie, b
 void EmiSockDelegate::connectionGotMessage(EC *conn,
                                            EmiUdpSocket<EmiBinding> *socket,
                                            EmiTimeInterval now,
-                                           const sockaddr_storage& inboundAddress,
-                                           const sockaddr_storage& remoteAddress,
+                                           sockaddr_storage inboundAddress,
+                                           sockaddr_storage remoteAddress,
                                            NSData *data,
                                            size_t offset,
                                            size_t len) {


### PR DESCRIPTION
Using a constref from a block that is dispatched async =
using stack memory from another thread that might be gone by the time
you have dispatched = crash
