### PR TITLE
Node-waf replaced by node-gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "eminet",
+      "sources": ['core/EmiNetUtil.cc', 'core/EmiRC4.cc', 'core/EmiConnTime.cc', 'core/EmiMessageHeader.cc', 'core/EmiPacketHeader.cc', 'core/EmiDataArrivalRate.cc', 'core/EmiLossList.cc', 'core/EmiLinkCapacity.cc', 'node/slab_allocator.cc', 'node/eminet.cc', 'node/EmiSocket.cc', 'node/EmiConnection.cc', 'node/EmiConnDelegate.cc', 'node/EmiSockDelegate.cc', 'node/EmiConnectionParams.cc', 'node/EmiError.cc', 'node/EmiNodeUtil.cc', 'node/EmiBinding.cc', 'node/EmiP2PSocket.cc']
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Per Eckerdal <per@emilir.com>",
   "engines": { "node" : ">=0.6.0" },
   "scripts": {
-    "preinstall": "node-waf configure build"
+    "preinstall": "node-gyp configure build"
   },
   "main": "./node/eminet"
 }


### PR DESCRIPTION
Node-waf is not available anymore. I know that this package is quite old and you don't maintain it anymore but I hope it will work for me. Thanks for that.
